### PR TITLE
soften language, remove accounts, add cybre.space example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,9 @@
 Blocked on Mastodon
 =======
 
-This is a list of Mastodon instances and accounts blocked by [toot.cafe](https://toot.cafe). If you think an instance or account has been unfairly blocked, please open an issue and/or a pull request.
+This is a list of Mastodon instances blocked by [toot.cafe](https://toot.cafe). If you think an instance has been unfairly blocked, please open an issue and/or a pull request.
 
-I'm doing this in order to be transparent and to collaborate with other instances on truly bad actors, at least "bad" insofar as they violate the commonly-accepted Code of Conduct based on [the example set by mastodon.social](https://mastodon.social/about/more).
-
-In certain exceptional circumstances I may block accounts/instances _without_ listing them here, in order to protect people's privacy, dignity, etc. But this is at least a subset, and it's an open forum for communication on the subject.
+I'm doing this in order to be transparent and to collaborate with other instance admins on identifying those instances that violate the commonly-accepted Code of Conduct based on [the example set by mastodon.social](https://mastodon.social/about/more) or tend to contain bad actors who do.
 
 Blocked instances
 ----
@@ -23,15 +21,9 @@ gs.smuglo.li
 unsafe.space
 ```
 
-Blocked accounts
-----
-
-```
-(none yet)
-```
-
 References
 ----
 
 - https://toot.cat/users/polymerwitch/updates/556
 - https://toot.cafe/@nolan/2937
+- https://cybre.space/users/chr/updates/2616


### PR DESCRIPTION
See discussion in #1 for some context.

Changes:

- Add reference to https://cybre.space/users/chr/updates/2616
- Soften/simplify the language a bit, no need to call instances "bad actors;" it's not about passing judgment but rather that not every instance needs to federate with every other one, and we are just being transparent about the guidelines we set and how we enforce those guidelines in order to keep these things fun and safe for our users. Keep in mind I wrote a lot of this original copy when I was very new to Mastodon.
- Remove reference to account moderation; I realized very quickly that this is not feasible because there are just too many accounts getting suspended/silenced all the time (e.g. followbots). Instance blocking is more infrequent though.