### PR TITLE
rename to blocked instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Blocked on Mastodon
+List of Toot Café Blocked Instances
 =======
 
 This is a list of Mastodon instances blocked by [toot.cafe](https://toot.cafe). If you think an instance has been unfairly blocked, please open an issue and/or a pull request.


### PR DESCRIPTION
I think "blocked instances" is a more accurate description of what this is now. I originally thought maybe we could list accounts here too but I'm learning that that just isn't feasible.