### PR TITLE
Tighten language: nazism isn't 'OK', but posting it is allowed

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Blocked instances
 ### Footnotes
 
 - \* Silenced vs suspended: silenced means they don't appear in the Federated timeline, but if someone discovers the accounts somehow (e.g. via replying to another toot) then they can follow and it will appear in their Home view.
-- \*\* "Free speech zone": a place where it's okay to promote e.g. National Socialism because the argument is that open discussion is more important than people's sensitivities or the denazification laws of Germany/France/etc. The term is not meant in a derogatory way; if there's a better one, let me know.
+- \*\* "Free speech zone": a place where it's permitted to post toots promoting e.g. National Socialism because the argument is that open discussion is more important than people's sensitivities or the denazification laws of Germany/France/etc. The term is not meant in a derogatory way; if there's a better one, let me know.
 - \*\*\* lolicon: sexualized depictions of children
 - \*\*\*\* content potentially unlawful in the U.S. under [FOSTA-SESTA](https://en.wikipedia.org/wiki/Stop_Enabling_Sex_Traffickers_Act)
 


### PR DESCRIPTION
Currently it reads like non-Mastodon-ToS instances are places where 'nazism is OK'. That's not correct: Nazism isn't OK on instances where people may post Nazi (or similar) comments - grown adults can and do call out people genuinely advocating nazism, communism, racism and sexism on those instances - merely that that users are allowed to post such content on those instances.